### PR TITLE
Run from source on Windows with wxPython 4.1.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ import uuid
 import requests
 import wx  # required for colour codes in DARK_MODE
 
+import re # for wxPython version dentification
+
 import optstore
 # cSpell Checker - Correct Words****************************************
 # // cSpell:words MEIPASS, datefmt, russsian, pyinstaller, posix, pyspy
@@ -34,6 +36,9 @@ def resource_path(relative_path):
 
     return os.path.join(base_path, relative_path)
 
+# Identify wxPython version (not wxWidgets version).
+wx_major, wx_minor, wx_rev = \
+        map(int, re.match(r"([0-9]+)\.([0-9]+)(?:\.([0-9]+))", wx.__version__).groups())
 
 # If application is frozen executable
 if getattr(sys, 'frozen', False):

--- a/gui.py
+++ b/gui.py
@@ -356,8 +356,12 @@ class Frame(wx.Frame):
         sizer_bottom.Add(self.status_label, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         static_line = wx.StaticLine(self, wx.ID_ANY, style=wx.LI_VERTICAL)
         sizer_bottom.Add(static_line, 0, wx.EXPAND, 0)
-        sizer_bottom.Add(self.alpha_slider, 0, wx.ALIGN_RIGHT, 0)
-        sizer_main.Add(sizer_bottom, 0, wx.ALIGN_BOTTOM | wx.ALL | wx.EXPAND, 1)
+        if config.wx_minor < 1:
+            sizer_bottom.Add(self.alpha_slider, 0, wx.ALIGN_RIGHT, 0)
+            sizer_main.Add(sizer_bottom, 0, wx.ALIGN_BOTTOM | wx.ALL | wx.EXPAND, 1)
+        else:
+            sizer_bottom.Add(self.alpha_slider)
+            sizer_main.Add(sizer_bottom, 0, wx.ALL | wx.EXPAND, 1)
         self.SetSizer(sizer_main)
         self.Layout()
         self._restoreColWidth()
@@ -640,7 +644,10 @@ class Frame(wx.Frame):
             for value in out:
                 color = False
                 self.grid.SetCellValue(rowidx, colidx, str(value))
-                self.grid.SetCellAlignment(self.columns[colidx][2], rowidx, colidx)
+                if config.wx_minor < 1:
+                    self.grid.SetCellAlignment(self.columns[colidx][2], rowidx, colidx)
+                else:
+                    self.grid.SetCellAlignment(rowidx, colidx, self.columns[colidx][2], wx.ALIGN_CENTER)
                 if hl_blops and r[9] is not None and r[11] > 0:  # Highlight BLOPS chars
                     self.grid.SetCellTextColour(rowidx, colidx, self.hl1_colour)
                     color = True

--- a/highlightdialog.py
+++ b/highlightdialog.py
@@ -100,7 +100,10 @@ class HighlightDialog(wx.Frame):
         buttonSizer.Add(self.appBtn, 1, wx.RIGHT, 5)
         buttonSizer.Add(self.cnclBtn, 1, wx.LEFT, 5)
         self.buttonPanel.SetSizer(buttonSizer)
-        main.Add(self.buttonPanel, 0, wx.ALIGN_BOTTOM | wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        if config.wx_minor < 1:
+            main.Add(self.buttonPanel, 0, wx.ALIGN_BOTTOM | wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        else:
+            main.Add(self.buttonPanel, 0, wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
         self.SetSizer(main)
         self.Layout()
         self.Centre()

--- a/ignoredialog.py
+++ b/ignoredialog.py
@@ -100,7 +100,10 @@ class IgnoreDialog(wx.Frame):
         buttonSizer.Add(self.appBtn, 1, wx.RIGHT, 5)
         buttonSizer.Add(self.cnclBtn, 1, wx.LEFT, 5)
         self.buttonPanel.SetSizer(buttonSizer)
-        main.Add(self.buttonPanel, 0, wx.ALIGN_BOTTOM | wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        if config.wx_minor < 1:
+            main.Add(self.buttonPanel, 0, wx.ALIGN_BOTTOM | wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        else:
+            main.Add(self.buttonPanel, 0, wx.BOTTOM | wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
         self.SetSizer(main)
         self.Layout()
         self.Centre()


### PR DESCRIPTION
I wanted to give it a try to PySpy and, as I have many Python things installed on my Windows, I wanted to run it from the sources (I was only missing pyperclip).

However, I am running wxPython 4.1.1 (I think it is the required version for Pyfa) and I could not run PySpy correctly. It seems the API has changed. So I fixed it while keeping the old code. However, I did not test it with wxPython 4.0.x.

It works flawlessly now with wxPython 4.1.1 on Windows (not tested on Linux, I should have...).